### PR TITLE
Fixed malformed localhost url / Added support for portable Browsers

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -7,15 +7,21 @@ module.exports =
         IE:
           cmd: 'start iexplore '
         Edge:
-          cmd: 'start microsoft-edge: '
+          cmd: 'start microsoft-edge '
         Chrome:
           cmd:  'start chrome '
+        ChromePortable:
+          cmd:  'start ' + atom.config.get('open-in-browsers.ChromePortablePath') + ' '
         Firefox:
           cmd:  'start firefox '
+        FirefoxPortable:
+          cmd:  'start ' + atom.config.get('open-in-browsers.FirefoxPortablePath') + ' '
         Opera:
           cmd: 'start opera '
         Safari:
           cmd: 'start safari '
+        SafariPortable:
+          cmd:  'start ' + atom.config.get('open-in-browsers.SafariPortablePath') + ' '
       win64:
         Edge:
           cmd: 'start microsoft-edge '
@@ -23,12 +29,18 @@ module.exports =
           cmd: 'start iexplore '
         Chrome:
           cmd:  'start chrome '
+        ChromePortable:
+          cmd:  'start ' + atom.config.get('open-in-browsers.ChromePortablePath') + ' '
         Firefox:
           cmd:  'start firefox '
+        FirefoxPortable:
+          cmd:  'start ' + atom.config.get('open-in-browsers.FirefoxPortablePath') + ' '
         Opera:
           cmd: 'start opera '
         Safari:
           cmd: 'start safari '
+        SafariPortable:
+          cmd:  'start ' + atom.config.get('open-in-browsers.SafariPortablePath') + ' '
 
       darwin:
         Chrome:

--- a/lib/open-in-browsers-view.coffee
+++ b/lib/open-in-browsers-view.coffee
@@ -30,6 +30,9 @@ class OpenInBrowsersView extends View
             browserClass = "fa #{browser}"
           if @curBrowser is browser
             browserClass  =+ " selected "
+            
+          unless atom.config.get("open-in-browsers.#{browser}Path") != ''
+            browserClass += " hide "
 
           @span class:browserClass,'data-browser':"#{browser}", mousedown:'openBrowser'
       @sup class:localhost, "L"
@@ -84,7 +87,7 @@ class OpenInBrowsersView extends View
       return false
     fpath = @getFilePath(target)
     cmd = "#{cmd} \"#{fpath}\""
-    cmd = cmd.replace '\\', '/'
+    cmd = cmd.replace "/\\/g", '/'
     exec  cmd if fpath
     @selectList?.cancel()
 

--- a/lib/open-in-browsers.coffee
+++ b/lib/open-in-browsers.coffee
@@ -6,7 +6,7 @@ module.exports = OpenInBrowsers =
     browsers:
       title: 'List of Browsers'
       type: 'array'
-      default: [ 'IE', 'Edge','Chrome', 'Firefox', 'Opera', 'Safari','BrowserPlus' ]
+      default: [ 'IE', 'Edge', 'Chrome', 'ChromePortable', 'Firefox', 'FirefoxPortable', 'Opera', 'Safari', 'SafariPortable', 'BrowserPlus' ]
 
     defBrowser:
       title: 'Default Browser'
@@ -22,17 +22,33 @@ module.exports = OpenInBrowsers =
       type: 'boolean'
       default: true
     Edge:
-      title: 'IE'
+      title: 'Edge'
       type: 'boolean'
       default: false
     Chrome:
       title: 'Chrome'
       type: 'boolean'
       default: true
+    ChromePortable:
+      title: 'Chrome Portable'
+      type: 'boolean'
+      default: true
+    ChromePortablePath:
+      title: 'Chrome Portable Path'
+      type: 'string'
+      default: ''
     Firefox:
       title: 'Firefox'
       type: 'boolean'
       default: true
+    FirefoxPortable:
+      title: 'Firefox Portable'
+      type: 'boolean'
+      default: true
+    FirefoxPortablePath:
+      title: 'Firefox Portable Path'
+      type: 'string'
+      default: ''
     Opera:
       title: 'Opera'
       type: 'boolean'
@@ -41,6 +57,14 @@ module.exports = OpenInBrowsers =
       title: 'Safari'
       type: 'boolean'
       default: true
+    SafariPortable:
+      title: 'Safari Portable'
+      type: 'boolean'
+      default: true
+    SafariPortablePath:
+      title: 'Safari Portable Path'
+      type: 'string'
+      default: ''
     BrowserPlus:
       title: 'Browser Plus'
       type: 'boolean'

--- a/styles/open-in-browsers.less
+++ b/styles/open-in-browsers.less
@@ -11,6 +11,12 @@
   color: green;
 }
 
+.FirefoxPortable:hover,
+.ChromePortable:hover,
+.SafariPortable:hover {
+  color: #17CA65 !important;
+}
+
 .open-in-browsers span{
   color: lightgrey;
   padding: 5px 10px;
@@ -77,13 +83,16 @@
 
 .octicon-browser::before { content: '\f0c5'; } /* ''  */
 
-.Safari::before {
+.Safari::before,
+.SafariPortable::before {
   .fa; content: "\f267";
 }
-.Chrome::before {
+.Chrome::before,
+.ChromePortable::before {
   .fa; content: "\f268";
 }
-.Firefox::before {
+.Firefox::before,
+.FirefoxPortable::before {
   .fa; content: "\f269";
 }
 .Opera::before {


### PR DESCRIPTION
Removed backward slashes in localhost URL with regex string.
Added Support for portable Browsers Firefox, Chrome and Safari on Windows.

Screenshot:
![open-in-browsers-portable-support](https://cloud.githubusercontent.com/assets/16726193/14671381/ca6e2648-06f1-11e6-86b0-835eb4f7b755.png)
